### PR TITLE
Cosmetic update of ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,10 @@ jobs:
         python-version: [3.11]
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Display Python version
-      run: |
-        echo "$pythonVersion = (python --version)" >> $GITHUB_OUTPUT
     - name: Install poetry
       run: |
         pip install poetry


### PR DESCRIPTION
Пока вчитывался в ci.yaml для понимания, заметил, что можно впихнуть отображение устанавливаемой версии Python прямо в имя стадии